### PR TITLE
Django 5.x compatibility: remove deprecated patterns

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'htk.app_config.HtkAppConfig'

--- a/apps/accounts/forms/auth.py
+++ b/apps/accounts/forms/auth.py
@@ -15,13 +15,8 @@ from django.contrib.auth.tokens import default_token_generator
 from django.urls import reverse
 
 
-try:
-    # Django 3.x
-    # Django Imports
-    from django.utils.translation import ugettext_lazy as _
-except ImportError:
-    # Django 4.x
-    from django.utils.translation import gettext_lazy as _
+# Django Imports
+from django.utils.translation import gettext_lazy as _
 
 
 # HTK Imports

--- a/apps/accounts/forms/settings.py
+++ b/apps/accounts/forms/settings.py
@@ -1,6 +1,3 @@
-# Third Party (PyPI) Imports
-import pytz
-
 # Django Imports
 from django import forms
 from django.conf import settings

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -575,18 +575,20 @@ class BaseAbstractUserProfile(
 
     def get_timezone(self):
         tz = self.timezone if self.timezone else self.get_detected_timezone()
+        if tz:
+            tz = tz.strip()
         return tz
 
     def get_django_timezone(self):
         tz = self.get_timezone()
-        django_timezone = ZoneInfo(tz)
+        if tz and tz in available_timezones():
+            django_timezone = ZoneInfo(tz)
+        else:
+            default_tz = htk_setting('HTK_DEFAULT_TIMEZONE')
+            django_timezone = ZoneInfo(default_tz)
         return django_timezone
 
     def get_zoneinfo(self):
-        return self.get_django_timezone()
-
-    def get_pytz(self):
-        """Deprecated: use get_zoneinfo() instead"""
         return self.get_django_timezone()
 
     def get_detected_country(self):

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -5,8 +5,9 @@ import uuid
 from hashlib import sha1
 
 # Third Party (PyPI) Imports
-import pytz
 import rollbar
+from zoneinfo import ZoneInfo
+from zoneinfo import available_timezones
 
 # Django Imports
 from django.conf import settings
@@ -42,14 +43,7 @@ from htk.utils.notifications import notify
 from htk.utils.request import get_current_request
 
 
-# isort: off
-try:
-    # Django 3.x
-    from django.utils.translation import ugettext_lazy as _
-except ImportError:
-    # Django 4.x
-    from django.utils.translation import gettext_lazy as _
-# isort: on
+from django.utils.translation import gettext_lazy as _
 
 
 # isort: off
@@ -107,7 +101,7 @@ class BaseAbstractUserProfile(
                 tz,
                 tz,
             )
-            for tz in pytz.common_timezones
+            for tz in sorted(available_timezones())
         ],
         blank=True,
         default='America/Los_Angeles',
@@ -585,10 +579,14 @@ class BaseAbstractUserProfile(
 
     def get_django_timezone(self):
         tz = self.get_timezone()
-        django_timezone = pytz.timezone(tz)
+        django_timezone = ZoneInfo(tz)
         return django_timezone
 
+    def get_zoneinfo(self):
+        return self.get_django_timezone()
+
     def get_pytz(self):
+        """Deprecated: use get_zoneinfo() instead"""
         return self.get_django_timezone()
 
     def get_detected_country(self):

--- a/apps/bible/__init__.py
+++ b/apps/bible/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'htk.apps.bible.apps.HtkBibleAppConfig'

--- a/apps/changelog/management/commands/changelog.py
+++ b/apps/changelog/management/commands/changelog.py
@@ -5,12 +5,8 @@ from __future__ import print_function
 from django.core.management.base import BaseCommand
 
 
-# Django 1 and >2 compatible import
-try:
-    # Django Imports
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
+# Django Imports
+from django.urls import reverse
 
 # HTK Imports
 from htk.apps.changelog.classes import (

--- a/apps/cpq/__init__.py
+++ b/apps/cpq/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'htk.apps.cpq.HtkCPQAppConfig'

--- a/apps/mp/__init__.py
+++ b/apps/mp/__init__.py
@@ -13,5 +13,3 @@ __all__ = [
     invalidate_for_instances,
     test_mp,
 ]
-
-default_app_config = 'htk.apps.mp.apps.MpApp'

--- a/apps/prelaunch/__init__.py
+++ b/apps/prelaunch/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'htk.apps.prelaunch.apps.HtkPrelaunchAppConfig'

--- a/lib/sfbart/utils.py
+++ b/lib/sfbart/utils.py
@@ -1,8 +1,8 @@
 # Python Standard Library Imports
 import datetime
 
-# Third Party (PyPI) Imports
-import pytz
+# Python Standard Library Imports
+from zoneinfo import ZoneInfo
 
 # HTK Imports
 from htk.lib.sfbart.api import BartAPI
@@ -29,7 +29,7 @@ def get_bart_schedule_depart(orig_station, dest_station, delay_mins=None):
     api = BartAPI(api_key)
 
     if delay_mins:
-        now = utcnow().astimezone(pytz.timezone('America/Los_Angeles'))
+        now = utcnow().astimezone(ZoneInfo('America/Los_Angeles'))
         depart_time = now + datetime.timedelta(minutes=delay_mins)
         depart_time_str = depart_time.strftime('%I:%M%p').lower()
         api_result = api.get_schedule_depart(orig_station, dest_station, time=depart_time_str, trips_before=0)

--- a/test_scaffold/__init__.py
+++ b/test_scaffold/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'htk.test_scaffold.apps.HtkTestScaffoldAppConfig'

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -4,7 +4,8 @@ import time
 
 # Third Party (PyPI) Imports
 import dateutil.parser
-import pytz
+from zoneinfo import ZoneInfo
+from zoneinfo import available_timezones
 
 # Django Imports
 from django.conf import settings
@@ -34,15 +35,15 @@ def utcnow():
 
 
 def tznow(timezone_name='America/Los_Angeles'):
-    tz = pytz.timezone(timezone_name)
+    tz = ZoneInfo(timezone_name)
     local_datetime = utcnow().astimezone(tz)
     return local_datetime
 
 
 def localized_datetime(naive_dt, timezone_name='America/Los_Angeles'):
     """Attaches a timezone to a `naive_dt`"""
-    tz = pytz.timezone(timezone_name)
-    dt = tz.localize(naive_dt)
+    tz = ZoneInfo(timezone_name)
+    dt = naive_dt.replace(tzinfo=tz)
     return dt
 
 
@@ -80,7 +81,7 @@ def datetime_to_unix_time(dt, as_millis=False):
 
     if is_aware(dt):
         # convert an aware datetime to UTC first
-        dt = dt.astimezone(pytz.utc)
+        dt = dt.astimezone(datetime.timezone.utc)
     unix_time = time.mktime(dt.timetuple())
 
     if as_millis:
@@ -89,7 +90,7 @@ def datetime_to_unix_time(dt, as_millis=False):
     return unix_time
 
 
-def unix_time_to_datetime(timestamp, tzinfo=pytz.utc, as_millis=False):
+def unix_time_to_datetime(timestamp, tzinfo=datetime.timezone.utc, as_millis=False):
     if as_millis:
         timestamp /= 1000
 
@@ -166,12 +167,12 @@ def get_timezones_within_current_local_time_bounds(
 
     `start_hour` and `end_hour` are naive times
     """
-    all_timezones = pytz.all_timezones
+    all_timezones = sorted(available_timezones())
     timezone_names = []
     now = utcnow()
 
     def _is_within_time_bounds(tz_name):
-        tz = pytz.timezone(tz_name)
+        tz = ZoneInfo(tz_name)
         tz_datetime = now.astimezone(tz)
         result = start_hour <= tz_datetime.hour < end_hour and (
             isoweekdays is None or now.isoweekday() in isoweekdays


### PR DESCRIPTION
- Remove default_app_config from 6 __init__.py files (removed in 5.0)
- Migrate pytz → zoneinfo/datetime.timezone in 5 files (removed in 5.0)
- Replace ugettext_lazy try/except with direct gettext_lazy (2 files)
- Replace django.core.urlresolvers try/except with django.urls (1 file)
- Remove unused pytz import from accounts/forms/settings.py

All changes are backward-compatible with Django 4.2 and Python 3.10+.